### PR TITLE
Changes to support rotors_simulator integration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # folders
-build
+build/
+install/
 
 # test files
 test_flow.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,5 +104,6 @@ target_include_directories(OpticalFlow PUBLIC include)
 configure_file(OpticalFlowConfig.cmake.in FindOpticalFlow.cmake @ONLY)
 
 # Append build dir to CMAKE_MODULE_PATH, so find_package(OpticalFlow) can find FindOpticalFlow.cmake
-message(STATUS "Appending ${CMAKE_CURRENT_BINARY_DIR} to CMAKE_MODULE_PATH.")
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_BINARY_DIR}")
+message(STATUS "Appending ${CMAKE_BINARY_DIR} to CMAKE_MODULE_PATH.")
+message(STATUS "CMAKE_BINARY_DIR = ${CMAKE_BINARY_DIR}")
+LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,11 +101,23 @@ endif()
 target_include_directories(OpticalFlow PUBLIC include)
 
 # Generate the Config file from the .in file, doing @VAR@ substitution only
-<<<<<<< HEAD
 configure_file(OpticalFlowConfig.cmake.in FindOpticalFlow.cmake @ONLY)
 
-# Append build dir to CMAKE_MODULE_PATH, so find_package(OpticalFlow) can find FindOpticalFlow.cmake
-message(STATUS "Appending ${CMAKE_BINARY_DIR} to CMAKE_MODULE_PATH.")
-message(STATUS "CMAKE_BINARY_DIR = ${CMAKE_BINARY_DIR}")
-# CMakeLists.txt no longer sets CMAKE_MODULE_PATH, this is up to the user (PX4 in this case)
-#LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")
+# INSTALL STEPS
+INSTALL(
+  TARGETS OpticalFlow
+  RUNTIME DESTINATION lib
+  LIBRARY DESTINATION lib)
+
+INSTALL(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/klt_feature_tracker/include/
+  DESTINATION include)
+
+INSTALL(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+  DESTINATION include)
+
+INSTALL(
+  FILES ${CMAKE_BINARY_DIR}/FindOpticalFlow.cmake
+  DESTINATION ${CMAKE_INSTALL_PREFIX})
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,9 +101,11 @@ endif()
 target_include_directories(OpticalFlow PUBLIC include)
 
 # Generate the Config file from the .in file, doing @VAR@ substitution only
+<<<<<<< HEAD
 configure_file(OpticalFlowConfig.cmake.in FindOpticalFlow.cmake @ONLY)
 
 # Append build dir to CMAKE_MODULE_PATH, so find_package(OpticalFlow) can find FindOpticalFlow.cmake
 message(STATUS "Appending ${CMAKE_BINARY_DIR} to CMAKE_MODULE_PATH.")
 message(STATUS "CMAKE_BINARY_DIR = ${CMAKE_BINARY_DIR}")
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")
+# CMakeLists.txt no longer sets CMAKE_MODULE_PATH, this is up to the user (PX4 in this case)
+#LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,11 +58,13 @@ set( klt_feature_tracker_LIBS "klt_feature_tracker" )
 if(OpenCV_FOUND)
     message(STATUS "Building ${PROJECT_NAME} with OpenCV")
 
-    include_directories(
-    	include
+    set(OpticalFlow_INCLUDE_DIRS 
+      ${CMAKE_CURRENT_SOURCE_DIR}/include
       ${klt_feature_tracker_INCLUDE_DIRS}
-    	${OpenCV_INCLUDE_DIRS}
+      ${OpenCV_INCLUDE_DIRS}
     )
+
+    include_directories(OpticalFlow_INCLUDE_DIRS)
 
     add_library( OpticalFlow SHARED
       src/optical_flow.cpp
@@ -78,10 +80,12 @@ if(OpenCV_FOUND)
 else()
     message(STATUS "Building ${PROJECT_NAME} without OpenCV")
 
-    include_directories(
-    	include
+    set(OpticalFlow_INCLUDE_DIRS 
+      ${CMAKE_CURRENT_SOURCE_DIR}/include
       ${klt_feature_tracker_INCLUDE_DIRS}
     )
+
+    include_directories(OpticalFlow_INCLUDE_DIRS)
 
     add_library( OpticalFlow SHARED
       src/optical_flow.cpp
@@ -95,3 +99,10 @@ else()
 endif()
 
 target_include_directories(OpticalFlow PUBLIC include)
+
+# Generate the Config file from the .in file, doing @VAR@ substitution only
+configure_file(OpticalFlowConfig.cmake.in FindOpticalFlow.cmake @ONLY)
+
+# Append build dir to CMAKE_MODULE_PATH, so find_package(OpticalFlow) can find FindOpticalFlow.cmake
+message(STATUS "Appending ${CMAKE_CURRENT_BINARY_DIR} to CMAKE_MODULE_PATH.")
+LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_BINARY_DIR}")

--- a/OpticalFlowConfig.cmake.in
+++ b/OpticalFlowConfig.cmake.in
@@ -1,0 +1,10 @@
+# - Config file for the OpticalFlow package
+# It defines the following variables
+#  OpticalFlow_INCLUDE_DIRS - include directories
+#  OpticalFlow_LIBRARIES    - libraries to link against
+ 
+set(OpticalFlow_INCLUDE_DIRS "@OpticalFlow_INCLUDE_DIRS@")
+ 
+set(OpticalFlow_LIBRARIES foo)
+
+# OpticalFlow_FOUND is set to "1" by FIND_PACKAGE().

--- a/OpticalFlowConfig.cmake.in
+++ b/OpticalFlowConfig.cmake.in
@@ -3,8 +3,6 @@
 #  OpticalFlow_INCLUDE_DIRS - include directories
 #  OpticalFlow_LIBRARIES    - libraries to link against
  
-set(OpticalFlow_INCLUDE_DIRS "@OpticalFlow_INCLUDE_DIRS@")
- 
-set(OpticalFlow_LIBRARIES foo)
-
-# OpticalFlow_FOUND is set to "1" by FIND_PACKAGE().
+set(OpticalFlow_INCLUDE_DIRS "@CMAKE_INSTALL_PREFIX@/include")
+set(OpticalFlow_LIBRARY_DIR "@CMAKE_INSTALL_PREFIX@/lib")
+set(OpticalFlow_LIBRARIES OpticalFlow)

--- a/OpticalFlowConfig.cmake.in
+++ b/OpticalFlowConfig.cmake.in
@@ -4,5 +4,5 @@
 #  OpticalFlow_LIBRARIES    - libraries to link against
  
 set(OpticalFlow_INCLUDE_DIRS "@CMAKE_INSTALL_PREFIX@/include")
-set(OpticalFlow_LIBRARY_DIR "@CMAKE_INSTALL_PREFIX@/lib")
-set(OpticalFlow_LIBRARIES OpticalFlow)
+#set(OpticalFlow_LIBRARY_DIR "@CMAKE_INSTALL_PREFIX@/lib")
+FIND_LIBRARY(OpticalFlow_LIBRARIES OpticalFlow PATHS "@CMAKE_INSTALL_PREFIX@/lib" NO_DEFAULT_PATH)


### PR DESCRIPTION
OpticalFlow can be now used just like any other 3rd party package in CMake, with a `find(OpticalFlow)` call.