### PR TITLE
Fix opencv includes

### DIFF
--- a/include/flow_opencv.hpp
+++ b/include/flow_opencv.hpp
@@ -41,11 +41,8 @@
 #pragma once
 
 #include <iostream>
-#include <cv.h>
+#include <opencv2/opencv.hpp>
 #include <cmath>
-
-#include "opencv2/features2d/features2d.hpp"
-#include "opencv2/video/tracking.hpp"
 
 #include "optical_flow.hpp"
 #include "trackFeatures.h"


### PR DESCRIPTION
The include file cv.h is no longer available starting with opencv 4.0.

Therefore, it makes sense to transition to the v2 includes.