### PR TITLE
cmake: don't specify built type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,6 @@ set(version "${version_major}.${version_minor}.${version_patch}")
 set(package-contact "christoph@px4.io")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic")
-set(CMAKE_BUILD_TYPE Release)
 
 set(${PROJECT_NAME}_INCLUDE_DIRS
     ${PROJECT_SOURCE_DIR}/include


### PR DESCRIPTION
This fixes this error when building with cmake 3.17 and ninja:

```
ninja: error: 'cmake_object_order_depends_target_OpticalFlow_', needed
by 'cmake_object_order_depends_target_gazebo_opticalflow_plugin_',
missing and no known rule to make it
```

As far as I know is the correct way to select the build type by passing it to cmake at configure time (`-DCMAKE_BUILD_TYPE=Release`) or as part of a toolchain file.