### PR TITLE
flow_opencv: fix implicit double promotion

### DIFF
--- a/src/flow_opencv.cpp
+++ b/src/flow_opencv.cpp
@@ -137,8 +137,8 @@ int OpticalFlowOpenCV::calcFlow(uint8_t *img_current, const uint32_t &img_time_u
 			//calculate variance
 			for (int i = 0; i < updateVector.size(); i++) {
 				if (updateVector[i] == 1) {
-					pixel_flow_x_stddev += pow(features_current[i].x - features_previous[i].x - pixel_flow_x_mean, 2);
-					pixel_flow_y_stddev += pow(features_current[i].y - features_previous[i].y - pixel_flow_y_mean, 2);
+					pixel_flow_x_stddev += powf(features_current[i].x - features_previous[i].x - pixel_flow_x_mean, 2);
+					pixel_flow_y_stddev += powf(features_current[i].y - features_previous[i].y - pixel_flow_y_mean, 2);
 				}
 			}
 


### PR DESCRIPTION
When building PX4, we get the warning

```
.../src/flow_opencv.cpp:140:61: warning: implicit conversion from ‘float’ to ‘__gnu_cxx::__promote<double>::__type’ {aka ‘double’} to match other operand of binary expression [-Wdouble-promotion]
      140 |                                         pixel_flow_x_stddev += pow(features_current[i].x - features_previous[i].x - pixel_flow_x_mean, 2);
          |                                         ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../src/flow_opencv.cpp:141:61: warning: implicit conversion from ‘float’ to ‘__gnu_cxx::__promote<double>::__type’ {aka ‘double’} to match other operand of binary expression [-Wdouble-promotion]
      141 |                                         pixel_flow_y_stddev += pow(features_current[i].y - features_previous[i].y - pixel_flow_y_mean, 2);
          |                                         ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

which is fixed by switching from `pow` to `powf`.