### PR TITLE
fix opencv deprecation warning

### DIFF
--- a/src/flow_opencv.cpp
+++ b/src/flow_opencv.cpp
@@ -72,16 +72,16 @@ OpticalFlowOpenCV::~OpticalFlowOpenCV(void)
 void OpticalFlowOpenCV::setCameraMatrix(float focal_len_x, float focal_len_y,
 					float principal_point_x, float principal_point_y)
 {
-	camera_matrix <<   focal_len_x, 0.0f, principal_point_x,
+	camera_matrix = cv::Mat(cv::Matx33f(focal_len_x, 0.0f, principal_point_x,
 		      0.0f, focal_len_y, principal_point_y,
-		      0.0f, 0.0f, 1.0f;
+		      0.0f, 0.0f, 1.0f));
 
 	set_camera_matrix = true;
 }
 
 void OpticalFlowOpenCV::setCameraDistortion(float k1, float k2, float k3, float p1, float p2)
 {
-	camera_distortion <<   k1, k2, p1, p2, k3;
+	camera_distortion = cv::Mat(cv::Matx<float, 1, 5>(k1, k2, p1, p2, k3));
 
 	set_camera_distortion = true;
 }


### PR DESCRIPTION
## Issue
OpenCV now issues the following warning for initializing the matrices with <<:

```
PX4-OpticalFlow/src/flow_opencv.cpp: In member function ‘void OpticalFlowOpenCV::setCameraMatrix(float, float, float, float)’:
PX4-OpticalFlow/src/flow_opencv.cpp:75:28: warning: ‘cv::MatCommaInitializer_<_Tp> cv::operator<<(const Mat_<_Tp>&, T2) [with _Tp = float; T2 = float]’ is deprecated [-Wdeprecated-declarations]
   75 |         camera_matrix <<   focal_len_x, 0.0f, principal_point_x,
      |                            ^~~~~~~~~~~
In file included from /usr/local/include/opencv4/opencv2/core/mat.hpp:3868,
                 from /usr/local/include/opencv4/opencv2/core.hpp:58,
                 from /usr/local/include/opencv4/opencv2/opencv.hpp:52,
                 from /home/ginny/development/PX4-OpticalFlow/include/flow_opencv.hpp:44,
                 from /home/ginny/development/PX4-OpticalFlow/src/flow_opencv.cpp:41:
/usr/local/include/opencv4/opencv2/core/mat.inl.hpp:3015:27: note: declared here
 3015 | MatCommaInitializer_<_Tp> operator << (const Mat_<_Tp>& m, T2 val)
      |                           ^~~~~~~~
PX4-OpticalFlow/src/flow_opencv.cpp: In member function ‘void OpticalFlowOpenCV::setCameraDistortion(float, float, float, float, float)’:
/home/ginny/development/PX4-OpticalFlow/src/flow_opencv.cpp:84:32: warning: ‘cv::MatCommaInitializer_<_Tp> cv::operator<<(const Mat_<_Tp>&, T2) [with _Tp = float; T2 = float]’ is deprecated [-Wdeprecated-declarations]
   84 |         camera_distortion <<   k1, k2, p1, p2, k3;
      |                                ^~
/usr/local/include/opencv4/opencv2/core/mat.inl.hpp:3015:27: note: declared here
 3015 | MatCommaInitializer_<_Tp> operator << (const Mat_<_Tp>& m, T2 val)
      |                           ^~~~~~~~
```

## Fix
This fixes the deprecation by explicitly initializing the matrices with constructors. 

## Testing
- OS: Ubuntu 24.04
- OpenCV: 4.13
Building now no longer shows the warning.